### PR TITLE
desc-tex Makefile fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,12 +63,13 @@ DIFF = $(DIFPRE)$(THISBRANCH)
 
 # if called with no target specified, compile the paper and the differences
 # but skip the differences if we're on MASTERBRANCH currently, or not in a git repo at all
-default: $(DESCTEX) $(DESCTEX)/.git $(PAPER).pdf
-ifneq ($(THISBRANCH),$(MASTERBRANCH))
-ifneq ($(THISBRANCH),)
-default: $(DIFF).pdf
-endif
-endif
+default: $(DESCTEX)/.git $(PAPER).pdf
+### latexdiff seems to be particularly fragile when dealing with this project, so don't do it by default
+##ifneq ($(THISBRANCH),$(MASTERBRANCH))
+##ifneq ($(THISBRANCH),)
+##default: $(DIFF).pdf
+##endif
+##endif
 
 $(PAPER): $(PAPER).pdf
 


### PR DESCRIPTION
1. Removes the erroneous `submodule add` recipe, which should never be needed.
2. Since latexdiff is causing so many problems, the diff pdf is no longer made by default.