### PR TITLE
Credit Planck Style Guide authors, provide link to issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Suggestions for changes should be posted to the LSST DESC Publications Board via
 
 ## Authors
 
-The 2017 DESC Publications Board:
-* Seth Digel (Publication Manager)
+The 2016-2018 DESC Publication Board:
 * Pierre Astier
+* Seth Digel (Publication Manager)
 * David Kirkby
 * Rachel Mandelbaum
 * Adam Mantz


### PR DESCRIPTION
@LSSTDESC/pubboard I implemented the suggested upgrade to origin section of the README suggested by @hiranyapeiris and discussed in the pubboard Slack channel. I left the tex as it is - really this PR is about making the README consistent with the credit statement in the document itself.

I also added a link to the repo's issues, to provide a way for changes to the Style Guide to be suggested. 